### PR TITLE
Feature/cli handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,10 +14,15 @@ dependencies {
         include '*.jar'
         include '*/*.jar'
     }
+    implementation 'org.apache.groovy:groovy-test:4.0.18'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.2'
+    testImplementation 'org.junit.vintage:junit-vintage-engine:5.9.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
 }
 
 test {
-    useJUnitPlatform()
+    useJUnitPlatform() {
+        includeEngines 'junit-vintage'
+        includeEngines 'junit-jupiter'
+    }
 }

--- a/src/main/groovy/cli/CliHandler.groovy
+++ b/src/main/groovy/cli/CliHandler.groovy
@@ -12,9 +12,10 @@ class CliHandler {
 
     def final static LOGGER = Logger.getLogger('CliHandler')
 
-    def cli
+    final def cli
+    final def args
+
     def options
-    def args
     def verbose
     def extraArguments
 
@@ -40,17 +41,18 @@ class CliHandler {
             printf FORMAT, VersionType.MINOR.versionType, 'Increments minor version number'
             printf FORMAT, VersionType.BUGFIX.versionType, 'Increments bugfix version number'
         }
+
+        options = cli.parse(args)
+        extraArguments = options.arguments().flatten().findAll{ it != null }
     }
 
     void handleCli() throws IncorrectLocationsProvided, IncorrectArgumentsNumber {
-        options = cli.parse(args)
-        extraArguments = options.arguments().flatten().findAll{ it != null }
-
         handleVerbose()
         printProvidedArguments()
 
         if (extraArguments.size() != 2) {
-            throw new IncorrectArgumentsNumber('Provided incorrect number of arguments')
+            throw new IncorrectArgumentsNumber('Provided incorrect number of arguments! Provided ' +
+                    'arguments number: ' + extraArguments.size())
         }
 
         handleFolderToScan()
@@ -83,7 +85,7 @@ class CliHandler {
             folderToScan = fileFolder.get(0)
         } else {
             throw new IncorrectLocationsProvided("Provided none or too many locations to scan by " +
-                    "the versioner")
+                    "the versioner! Provided locations: " + fileFolder.size())
         }
 
         if (verbose) {
@@ -91,7 +93,7 @@ class CliHandler {
         }
     }
 
-    void handleVersionType() {
+    void handleVersionType() throws IncorrectVersionNumber {
         def versionTypes = VersionType.values().versionType
 
         if (verbose) {
@@ -104,7 +106,8 @@ class CliHandler {
         }
 
         if (versions.size() != 1) {
-            throw new IncorrectVersionNumber('Provided incorrect number of version types')
+            throw new IncorrectVersionNumber('Provided incorrect number of version types! ' +
+                    'Provided arguments: ' + versions.size())
         }
         versionType = versions.get(0)
     }

--- a/src/main/groovy/cli/CliHandler.groovy
+++ b/src/main/groovy/cli/CliHandler.groovy
@@ -1,0 +1,34 @@
+package cli
+
+import groovy.cli.commons.CliBuilder
+import version.Version
+
+class CliHandler {
+
+    def cli
+    def options
+    def args
+
+    CliHandler(args) {
+        this.args = args
+        this.cli = new CliBuilder(usage: 'versioner-q -[options]')
+
+        cli.with {
+            h longOpt: 'help', 'Show usage information'
+            v longOpt: 'version', 'Show software version'
+            g longOpt: 'gradle', 'Update Gradle project version'
+        }
+    }
+
+    void handleCli() {
+        options = cli.parse(args)
+
+        if (options.h) {
+            cli.usage()
+        }
+
+        if (options.v) {
+            Version.printVersion()
+        }
+    }
+}

--- a/src/main/groovy/cli/CliHandler.groovy
+++ b/src/main/groovy/cli/CliHandler.groovy
@@ -3,21 +3,28 @@ package cli
 import groovy.cli.commons.CliBuilder
 import version.Version
 
+import java.util.logging.Logger
+
 class CliHandler {
 
     def final static FORMAT = ' %-15s%s\n'
 
+    def final static LOGGER = Logger.getLogger('CliHandler')
+
     def cli
     def options
     def args
+    def verbose
 
     CliHandler(args) {
         this.args = args
         this.cli = new CliBuilder(usage: 'versioner-q -[options] <versionType>')
+        this.verbose = false
 
         cli.with {
             h longOpt: 'help', 'Show usage information'
             v longOpt: 'version', 'Show software version'
+            _ longOpt: 'verbose', 'Show more output'
             g longOpt: 'gradle', 'Update Gradle project version'
         }
 
@@ -31,6 +38,11 @@ class CliHandler {
 
     void handleCli() {
         options = cli.parse(args)
+
+        if (options.'verbose') {
+            verbose = true
+            LOGGER.info('Logging more data from now on')
+        }
 
         if (options.h) {
             cli.usage()

--- a/src/main/groovy/cli/CliHandler.groovy
+++ b/src/main/groovy/cli/CliHandler.groovy
@@ -20,6 +20,7 @@ class CliHandler {
 
     def projectType
     def folderToScan
+    def versionType
 
     CliHandler(args) {
         this.args = args
@@ -35,9 +36,9 @@ class CliHandler {
 
         cli.metaClass.versionTypes() {
             println '\nPossible version types: '
-            printf FORMAT, 'major', 'Increments major version number'
-            printf FORMAT, 'minor', 'Increments minor version number'
-            printf FORMAT, 'bugfix', 'Increments bugfix version number'
+            printf FORMAT, VersionType.MAJOR.versionType, 'Increments major version number'
+            printf FORMAT, VersionType.MINOR.versionType, 'Increments minor version number'
+            printf FORMAT, VersionType.BUGFIX.versionType, 'Increments bugfix version number'
         }
     }
 
@@ -53,6 +54,7 @@ class CliHandler {
         }
 
         handleFolderToScan()
+        handleVersionType()
 
         handleHelp()
         handleVersion()
@@ -87,6 +89,24 @@ class CliHandler {
         if (verbose) {
             LOGGER.info('Found fileFolder(s): ' + fileFolder)
         }
+    }
+
+    void handleVersionType() {
+        def versionTypes = VersionType.values().versionType
+
+        if (verbose) {
+            println 'Available version types: ' + versionTypes
+        }
+
+        def versions = extraArguments.intersect(versionTypes)
+        if (verbose) {
+            println 'Found version types in arguments: ' + versions
+        }
+
+        if (versions.size() != 1) {
+            throw new IncorrectVersionNumber('Provided incorrect number of version types')
+        }
+        versionType = versions.get(0)
     }
 
     void handleHelp() {

--- a/src/main/groovy/cli/CliHandler.groovy
+++ b/src/main/groovy/cli/CliHandler.groovy
@@ -5,18 +5,27 @@ import version.Version
 
 class CliHandler {
 
+    def final static FORMAT = ' %-15s%s\n'
+
     def cli
     def options
     def args
 
     CliHandler(args) {
         this.args = args
-        this.cli = new CliBuilder(usage: 'versioner-q -[options]')
+        this.cli = new CliBuilder(usage: 'versioner-q -[options] <versionType>')
 
         cli.with {
             h longOpt: 'help', 'Show usage information'
             v longOpt: 'version', 'Show software version'
             g longOpt: 'gradle', 'Update Gradle project version'
+        }
+
+        cli.metaClass.versionTypes() {
+            println '\nPossible version types: '
+            printf FORMAT, 'major', 'Increments major version number'
+            printf FORMAT, 'minor', 'Increments minor version number'
+            printf FORMAT, 'bugfix', 'Increments bugfix version number'
         }
     }
 
@@ -25,6 +34,7 @@ class CliHandler {
 
         if (options.h) {
             cli.usage()
+            cli.versionTypes()
         }
 
         if (options.v) {

--- a/src/main/groovy/cli/CliHandler.groovy
+++ b/src/main/groovy/cli/CliHandler.groovy
@@ -41,12 +41,16 @@ class CliHandler {
         }
     }
 
-    void handleCli() throws IncorrectLocationsProvided {
+    void handleCli() throws IncorrectLocationsProvided, IncorrectArgumentsNumber {
         options = cli.parse(args)
         extraArguments = options.arguments().flatten().findAll{ it != null }
 
         handleVerbose()
         printProvidedArguments()
+
+        if (extraArguments.size() != 2) {
+            throw new IncorrectArgumentsNumber('Provided incorrect number of arguments')
+        }
 
         handleFolderToScan()
 
@@ -63,6 +67,7 @@ class CliHandler {
 
     void printProvidedArguments() {
         if (verbose) {
+            LOGGER.info('Arguments size: ' + extraArguments.size())
             LOGGER.info('Provided arguments: ' + extraArguments)
         }
     }

--- a/src/main/groovy/cli/IncorrectArgumentsNumber.groovy
+++ b/src/main/groovy/cli/IncorrectArgumentsNumber.groovy
@@ -1,0 +1,8 @@
+package cli
+
+class IncorrectArgumentsNumber extends Exception {
+
+    IncorrectArgumentsNumber(String message) {
+        super(message)
+    }
+}

--- a/src/main/groovy/cli/IncorrectLocationsProvided.groovy
+++ b/src/main/groovy/cli/IncorrectLocationsProvided.groovy
@@ -1,0 +1,8 @@
+package cli
+
+class IncorrectLocationsProvided extends Exception {
+
+    IncorrectLocationsProvided(String message) {
+        super(message)
+    }
+}

--- a/src/main/groovy/cli/IncorrectVersionNumber.groovy
+++ b/src/main/groovy/cli/IncorrectVersionNumber.groovy
@@ -1,0 +1,8 @@
+package cli
+
+class IncorrectVersionNumber extends Exception {
+
+    IncorrectVersionNumber(String message) {
+        super(message)
+    }
+}

--- a/src/main/groovy/cli/VersionType.groovy
+++ b/src/main/groovy/cli/VersionType.groovy
@@ -1,0 +1,14 @@
+package cli
+
+enum VersionType {
+
+    MAJOR('major'),
+    MINOR('minor'),
+    BUGFIX('bugfix')
+
+    def versionType
+
+    VersionType(versionType) {
+        this.versionType = versionType
+    }
+}

--- a/src/main/groovy/cli/VersionType.groovy
+++ b/src/main/groovy/cli/VersionType.groovy
@@ -6,7 +6,7 @@ enum VersionType {
     MINOR('minor'),
     BUGFIX('bugfix')
 
-    def versionType
+    final def versionType
 
     VersionType(versionType) {
         this.versionType = versionType

--- a/src/main/groovy/version/Version.groovy
+++ b/src/main/groovy/version/Version.groovy
@@ -2,7 +2,7 @@ package version
 
 class Version {
 
-    def static final VERSION = '0.0.8.1'
+    def static final VERSION = '0.0.8.2'
 
     static printVersion() {
         printVersionQ()

--- a/src/main/groovy/version/Version.groovy
+++ b/src/main/groovy/version/Version.groovy
@@ -2,7 +2,7 @@ package version
 
 class Version {
 
-    def static final VERSION = '0.0.8.0'
+    def static final VERSION = '0.0.8.1'
 
     static printVersion() {
         printVersionQ()

--- a/src/main/groovy/version/Version.groovy
+++ b/src/main/groovy/version/Version.groovy
@@ -2,7 +2,7 @@ package version
 
 class Version {
 
-    def static final VERSION = '0.0.2.0'
+    def static final VERSION = '0.0.3.0'
 
     static printVersion() {
         printVersionQ()

--- a/src/main/groovy/version/Version.groovy
+++ b/src/main/groovy/version/Version.groovy
@@ -2,7 +2,7 @@ package version
 
 class Version {
 
-    def static final VERSION = '0.0.4.0'
+    def static final VERSION = '0.0.5.0'
 
     static printVersion() {
         printVersionQ()

--- a/src/main/groovy/version/Version.groovy
+++ b/src/main/groovy/version/Version.groovy
@@ -2,7 +2,7 @@ package version
 
 class Version {
 
-    def static final VERSION = '0.0.3.0'
+    def static final VERSION = '0.0.4.0'
 
     static printVersion() {
         printVersionQ()

--- a/src/main/groovy/version/Version.groovy
+++ b/src/main/groovy/version/Version.groovy
@@ -2,7 +2,7 @@ package version
 
 class Version {
 
-    def static final VERSION = '0.0.0.1'
+    def static final VERSION = '0.0.2.0'
 
     static printVersion() {
         printVersionQ()

--- a/src/main/groovy/version/Version.groovy
+++ b/src/main/groovy/version/Version.groovy
@@ -2,7 +2,7 @@ package version
 
 class Version {
 
-    def static final VERSION = '0.0.6.0'
+    def static final VERSION = '0.0.7.0'
 
     static printVersion() {
         printVersionQ()

--- a/src/main/groovy/version/Version.groovy
+++ b/src/main/groovy/version/Version.groovy
@@ -1,0 +1,19 @@
+package version
+
+class Version {
+
+    def static final VERSION = '0.0.0.1'
+
+    static printVersion() {
+        printVersionQ()
+        printGroovyVersion()
+    }
+
+    static printVersionQ() {
+        println 'Version-Q: ' + VERSION
+    }
+
+    static printGroovyVersion() {
+        println 'Groovy: ' + GroovySystem.getVersion()
+    }
+}

--- a/src/main/groovy/version/Version.groovy
+++ b/src/main/groovy/version/Version.groovy
@@ -2,7 +2,7 @@ package version
 
 class Version {
 
-    def static final VERSION = '0.0.8.2'
+    def static final VERSION = '0.1.0.0'
 
     static printVersion() {
         printVersionQ()

--- a/src/main/groovy/version/Version.groovy
+++ b/src/main/groovy/version/Version.groovy
@@ -2,7 +2,7 @@ package version
 
 class Version {
 
-    def static final VERSION = '0.0.7.0'
+    def static final VERSION = '0.0.7.1'
 
     static printVersion() {
         printVersionQ()

--- a/src/main/groovy/version/Version.groovy
+++ b/src/main/groovy/version/Version.groovy
@@ -2,7 +2,7 @@ package version
 
 class Version {
 
-    def static final VERSION = '0.0.7.1'
+    def static final VERSION = '0.0.8.0'
 
     static printVersion() {
         printVersionQ()

--- a/src/main/groovy/version/Version.groovy
+++ b/src/main/groovy/version/Version.groovy
@@ -2,7 +2,7 @@ package version
 
 class Version {
 
-    def static final VERSION = '0.0.5.0'
+    def static final VERSION = '0.0.6.0'
 
     static printVersion() {
         printVersionQ()

--- a/src/main/groovy/versioner-q.bat
+++ b/src/main/groovy/versioner-q.bat
@@ -1,0 +1,11 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set "arguments="
+
+for %%i in (%*) do (
+    set "arguments=!arguments! %%i"
+)
+
+echo Versioner-Q
+groovy -cp %~dp0 %~dp0/versioner-q.groovy %arguments:~1%

--- a/src/main/groovy/versioner-q.bat
+++ b/src/main/groovy/versioner-q.bat
@@ -7,5 +7,4 @@ for %%i in (%*) do (
     set "arguments=!arguments! %%i"
 )
 
-echo Versioner-Q
-groovy -cp %~dp0 %~dp0/versioner-q.groovy %arguments:~1%
+groovy -cp %~dp0 %~dp0/versioner-q.groovy %arguments:~1% %cd%

--- a/src/main/groovy/versioner-q.groovy
+++ b/src/main/groovy/versioner-q.groovy
@@ -1,3 +1,22 @@
 #!/usr/bin/env groovy
-println 'Hello'
+import groovy.cli.commons.CliBuilder
+import version.Version
+
+def cli = new CliBuilder(usage: 'versioner-q -[options]')
+
+cli.with {
+    h longOpt: 'help', 'Show usage information'
+    v longOpt: 'version', 'Show software version'
+    g longOpt: 'gradle', 'Update Gradle project version'
+}
+
+def options = cli.parse(args)
+
+if (options.h) {
+    cli.usage()
+}
+
+if (options.v) {
+    Version.printVersion()
+}
 

--- a/src/main/groovy/versioner-q.groovy
+++ b/src/main/groovy/versioner-q.groovy
@@ -1,0 +1,3 @@
+#!/usr/bin/env groovy
+println 'Hello'
+

--- a/src/main/groovy/versioner-q.groovy
+++ b/src/main/groovy/versioner-q.groovy
@@ -1,5 +1,6 @@
 #!/usr/bin/env groovy
 import cli.CliHandler
+import cli.IncorrectArgumentsNumber
 import cli.IncorrectLocationsProvided
 
 import java.util.logging.Logger
@@ -13,6 +14,10 @@ CliHandler cliHandler = new CliHandler(args)
 
 try {
     cliHandler.handleCli()
+} catch (IncorrectArgumentsNumber e) {
+    LOGGER.severe(e.getMessage())
+    println 'Provided incorrect number of arguments'
+    println 'Application expects only revision type'
 } catch (IncorrectLocationsProvided e) {
     LOGGER.severe(e.getMessage())
     println 'Provided too many or too little locations for versioner too scan'

--- a/src/main/groovy/versioner-q.groovy
+++ b/src/main/groovy/versioner-q.groovy
@@ -1,6 +1,20 @@
 #!/usr/bin/env groovy
 import cli.CliHandler
+import cli.IncorrectLocationsProvided
+
+import java.util.logging.Logger
+
+
+def final LOGGER = Logger.getLogger('CliHandler')
+
+println 'Versioner-Q'
 
 CliHandler cliHandler = new CliHandler(args)
 
-cliHandler.handleCli()
+try {
+    cliHandler.handleCli()
+} catch (IncorrectLocationsProvided e) {
+    LOGGER.severe(e.getMessage())
+    println 'Provided too many or too little locations for versioner too scan'
+    println 'Do not provide location to scan - run versioner from folder to scan'
+}

--- a/src/main/groovy/versioner-q.groovy
+++ b/src/main/groovy/versioner-q.groovy
@@ -4,5 +4,3 @@ import cli.CliHandler
 CliHandler cliHandler = new CliHandler(args)
 
 cliHandler.handleCli()
-
-

--- a/src/main/groovy/versioner-q.groovy
+++ b/src/main/groovy/versioner-q.groovy
@@ -1,22 +1,8 @@
 #!/usr/bin/env groovy
-import groovy.cli.commons.CliBuilder
-import version.Version
+import cli.CliHandler
 
-def cli = new CliBuilder(usage: 'versioner-q -[options]')
+CliHandler cliHandler = new CliHandler(args)
 
-cli.with {
-    h longOpt: 'help', 'Show usage information'
-    v longOpt: 'version', 'Show software version'
-    g longOpt: 'gradle', 'Update Gradle project version'
-}
+cliHandler.handleCli()
 
-def options = cli.parse(args)
-
-if (options.h) {
-    cli.usage()
-}
-
-if (options.v) {
-    Version.printVersion()
-}
 

--- a/src/test/groovy/cli/CliHandlerTest.groovy
+++ b/src/test/groovy/cli/CliHandlerTest.groovy
@@ -1,0 +1,135 @@
+package cli
+
+import groovy.test.GroovyTestCase
+
+import static org.junit.jupiter.api.Assertions.assertThrows
+
+class CliHandlerTest extends GroovyTestCase {
+
+    private final static def LOCATION = 'C:/users/project'
+
+    void testShouldInitialise() {
+        // Given
+        def args = ['-h', LOCATION]
+
+        // When
+        CliHandler cliHandler = new CliHandler(args)
+
+        // Then
+        assertEquals(args, cliHandler.args)
+        assertNotNull(cliHandler.cli)
+        assertNotNull(cliHandler.options)
+        assertNotNull(cliHandler.extraArguments)
+        assertTrue(cliHandler.options.h)
+        assertEquals(LOCATION, cliHandler.extraArguments.get(0))
+        assertFalse(cliHandler.verbose)
+    }
+
+    void testShouldHandleVerbose() {
+        // Given
+        def args = ['--verbose', LOCATION]
+        CliHandler cliHandler = new CliHandler(args)
+
+        // When
+        cliHandler.handleVerbose()
+
+        // Then
+        assertTrue(cliHandler.verbose)
+    }
+
+    void testShouldHandleFolders() {
+        // Given
+        def args = ['--verbose', LOCATION]
+        CliHandler cliHandler = new CliHandler(args)
+
+        // When
+        cliHandler.handleFolderToScan()
+
+        // Then
+        assert LOCATION == cliHandler.folderToScan
+    }
+
+    void testShouldThrow_WhenNoLocationProvided() {
+        // Given
+        def args = ['--verbose']
+        CliHandler cliHandler = new CliHandler(args)
+
+        // When + Then
+        assertThrows(IncorrectLocationsProvided.class,
+                () -> cliHandler.handleFolderToScan())
+    }
+
+    void testShouldThrow_WhenTooManyLocationsProvided() {
+        // Given
+        def args = ['--verbose', LOCATION, LOCATION]
+        CliHandler cliHandler = new CliHandler(args)
+
+        // When + Then
+        assertThrows(IncorrectLocationsProvided.class,
+                () -> cliHandler.handleFolderToScan())
+    }
+
+    void testShouldHandleVersionType() {
+        // Given
+        def args = ['--verbose', LOCATION, 'major']
+        CliHandler cliHandler = new CliHandler(args)
+
+        // When
+        cliHandler.handleVersionType()
+
+        // Then
+        assert 'major' == cliHandler.versionType
+    }
+
+    void testShouldThrow_WhenNoVersionTypeProvided() {
+        // Given
+        def args = ['--verbose', LOCATION]
+        CliHandler cliHandler = new CliHandler(args)
+
+        // When + Then
+        assertThrows(IncorrectVersionNumber.class,
+                () -> cliHandler.handleVersionType())
+    }
+
+    void testShouldThrow_WhenTooManyVersionTypesProvided() {
+        // Given
+        def args = ['--verbose', LOCATION, 'major', 'minor']
+        CliHandler cliHandler = new CliHandler(args)
+
+        // When + Then
+        assertThrows(IncorrectVersionNumber.class,
+                () -> cliHandler.handleVersionType())
+    }
+
+    void testShouldHandleCli() {
+        // Given
+        def args = ['--verbose', LOCATION, 'major']
+        CliHandler cliHandler = new CliHandler(args)
+
+        // When
+        cliHandler.handleCli()
+
+        // Then
+        assert 'major' == cliHandler.versionType
+        assert LOCATION == cliHandler.folderToScan
+        assertTrue(cliHandler.verbose)
+    }
+
+    void testShouldThrow_WhenTooLittleArgumentsProvided() {
+        // Given
+        def args = ['--verbose', LOCATION]
+        CliHandler cliHandler = new CliHandler(args)
+
+        // When
+        assertThrows(IncorrectArgumentsNumber.class, () -> cliHandler.handleCli())
+    }
+
+    void testShouldThrow_WhenTooManyArgumentsProvided() {
+        // Given
+        def args = ['--verbose', LOCATION, 'major', LOCATION]
+        CliHandler cliHandler = new CliHandler(args)
+
+        // When
+        assertThrows(IncorrectArgumentsNumber.class, () -> cliHandler.handleCli())
+    }
+}

--- a/src/test/groovy/cli/VersionTypeTest.groovy
+++ b/src/test/groovy/cli/VersionTypeTest.groovy
@@ -1,0 +1,27 @@
+package cli
+
+import groovy.test.GroovyTestCase
+
+class VersionTypeTest extends GroovyTestCase {
+
+    void testGetMajor() {
+        // Given + When
+        def major = VersionType.MAJOR.versionType
+        // Then
+        assert major == 'major'
+    }
+
+    void testGetMinor() {
+        // Given + When
+        def minor = VersionType.MINOR.versionType
+        // Then
+        assert minor == 'minor'
+    }
+
+    void testGetBugfix() {
+        // Given + When
+        def bugfix = VersionType.BUGFIX.versionType
+        //Then
+        assert bugfix == 'bugfix'
+    }
+}


### PR DESCRIPTION
Added CliHandler to handle option and arguments input. Available options: --help ('-h'), --version ('-v'), --verbose. Availabe arguments - folder to scan for version controlled documents and version to bump (major, minor, bugfix).

Added .bat script wrapper that triggers groovy script - it will handle providing the folder location.

Added tests for CliHandler and version control.